### PR TITLE
Fix: Global CSS 수정

### DIFF
--- a/app/(auth)/layout.styles.ts
+++ b/app/(auth)/layout.styles.ts
@@ -3,6 +3,6 @@
 import styled from 'styled-components';
 
 export const LayoutWrapper = styled.div`
-  padding: 40px 16px;
+  padding: 84px 16px;
   width: 100%;
 `;

--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -14,29 +14,29 @@ import SocialLogin from '@/components/Layout/Login/SNSLogos';
 
 const Login = () => {
   return (
-    <LoginWrapper>
-      <LoginLogo src="" />
-      <LoginTitle>Where am I?</LoginTitle>
-      <Input title="이메일" placeholder="이메일을 입력해주세요" />
-      <Input
-        title="비밀번호"
-        placeholder="비밀번호를 입력해주세요"
-        isButton
-        isHiddenPassword
-      />
-      <AutoLoginCheckbox />
-      <ButtonSignupWrapper>
-        <Button
-          buttonType="gray"
-          buttonSize="large"
-          buttonHeight="default"
-          styleType="coloredBackground"
-          label="로그인"
+      <LoginWrapper>
+        <LoginLogo src="" />
+        <LoginTitle>Where am I?</LoginTitle>
+        <Input title="이메일" placeholder="이메일을 입력해주세요" />
+        <Input
+          title="비밀번호"
+          placeholder="비밀번호를 입력해주세요"
+          isButton
+          isHiddenPassword
         />
-        <SignupTabs />
-      </ButtonSignupWrapper>
-      <SocialLogin />
-    </LoginWrapper>
+        <AutoLoginCheckbox />
+        <ButtonSignupWrapper>
+          <Button
+            buttonType="gray"
+            buttonSize="large"
+            buttonHeight="default"
+            styleType="coloredBackground"
+            label="로그인"
+          />
+          <SignupTabs />
+        </ButtonSignupWrapper>
+        <SocialLogin />
+      </LoginWrapper>
   );
 };
 

--- a/app/(auth)/signup/Signup.styles.ts
+++ b/app/(auth)/signup/Signup.styles.ts
@@ -10,4 +10,5 @@ export const Title = styled.div`
   text-align: center;
   line-height: 150%;
   margin-bottom: 40px;
+  padding-top:40px
 `;

--- a/app/(auth)/signup/page.tsx
+++ b/app/(auth)/signup/page.tsx
@@ -2,8 +2,10 @@
 
 import NickNameInput from '@/components/Layout/Signup/NickNameInput';
 import Input from '@/components/Common/Input/Input';
+import { PageWrapper } from '@/app/commonPage.styles';
 import { SignupWrapper, Title } from './Signup.styles';
 import { useState } from 'react';
+import TopBar from '@/components/Common/TopBar/TopBar';
 
 const Signup = () => {
   const [isHiddenPassword, setIsHiddenPassword] = useState({
@@ -19,29 +21,34 @@ const Signup = () => {
   };
 
   return (
-    <SignupWrapper>
-      <Title>
-        어데고?!에서 사용할
-        <br />
-        닉네임, 아이디, 비밀번호를 입력해주세요.
-      </Title>
-      <NickNameInput />
-      <Input title="아이디" placeholder="아이디를 입력해주세요" />
-      <Input
-        title="비밀번호"
-        placeholder="비밀번호를 입력해주세요"
-        isButton={true}
-        isHiddenPassword={isHiddenPassword.origin}
-        handleClick={() => handleClick('origin')}
-      />
-      <Input
-        title="비밀번호 확인"
-        placeholder="비밀번호를 재입력해주세요"
-        isButton={true}
-        isHiddenPassword={isHiddenPassword.copy}
-        handleClick={() => handleClick('copy')}
-      />
-    </SignupWrapper>
+    <>
+    <TopBar NavType="default" label="회원가입" />
+    <PageWrapper>
+      <SignupWrapper>
+        <Title>
+          어데고?!에서 사용할
+          <br />
+          닉네임, 아이디, 비밀번호를 입력해주세요.
+        </Title>
+        <NickNameInput />
+        <Input title="아이디" placeholder="아이디를 입력해주세요" />
+        <Input
+          title="비밀번호"
+          placeholder="비밀번호를 입력해주세요"
+          isButton={true}
+          isHiddenPassword={isHiddenPassword.origin}
+          handleClick={() => handleClick('origin')}
+        />
+        <Input
+          title="비밀번호 확인"
+          placeholder="비밀번호를 재입력해주세요"
+          isButton={true}
+          isHiddenPassword={isHiddenPassword.copy}
+          handleClick={() => handleClick('copy')}
+        />
+      </SignupWrapper>
+    </PageWrapper>
+    </>
   );
 };
 

--- a/app/(nav)/groupList/page.tsx
+++ b/app/(nav)/groupList/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 import TopBar from "@/components/Common/TopBar/TopBar";
 import RoomButton from "@/components/Common/RoomButton/RoomButton";
-import { PageWrapper } from "../commonPage.styles";
+import { PageWrapper } from "../../commonPage.styles";
 import { RoomButtonGrid,ListTitle, SubTitle } from './groupList.styles';
 import MakeRoom from "@/components/Common/MakeRoom/MakeRoom";
 

--- a/app/(nav)/home/Home.styles.ts
+++ b/app/(nav)/home/Home.styles.ts
@@ -9,6 +9,5 @@ export const ChannelWrapper = styled.div`
   display: flex;
   flex-direction: column;
   gap: 10px;
-  margin-bottom: 80px;
 `;
 

--- a/app/(nav)/home/page.tsx
+++ b/app/(nav)/home/page.tsx
@@ -4,27 +4,22 @@ import TopBar from '@/components/Common/TopBar/TopBar';
 import { MainBanner } from '@/components/Layout/Home/MainBanner/MainBanner';
 import ChannelButton from '@/components/Layout/Home/ChannelButton/ChannelButton';
 import { HomeTitle,ChannelWrapper} from './Home.styles';
+import { MainTopWrapper } from './../../commonPage.styles';
 
 const Home = () => {
   return (
     <>
       <TopBar NavType="main" />
-      <MainBanner />
-      <HomeTitle>게임채널</HomeTitle>
-      <ChannelWrapper>
-        <Link href="/groupList">
-          <ChannelButton title="그룹 게임" />
-        </Link>
-        <ChannelButton title="랭킹 게임" />
-      </ChannelWrapper>
-      {/* <HomeWrapper>
-        <RoomButton
-          title="방제목"
-          hostUser="유저명"
-          groupMemberCount={3}
-          maxMemberCount={8}
-        />
-      </HomeWrapper> */}
+      <MainTopWrapper>
+        <MainBanner />
+        <HomeTitle>게임채널</HomeTitle>
+        <ChannelWrapper>
+          <Link href="/groupList">
+            <ChannelButton title="그룹 게임" />
+          </Link>
+          <ChannelButton title="랭킹 게임" />
+        </ChannelWrapper>
+      </MainTopWrapper>
     </>
   );
 };

--- a/app/(nav)/home/page.tsx
+++ b/app/(nav)/home/page.tsx
@@ -4,13 +4,12 @@ import TopBar from '@/components/Common/TopBar/TopBar';
 import { MainBanner } from '@/components/Layout/Home/MainBanner/MainBanner';
 import ChannelButton from '@/components/Layout/Home/ChannelButton/ChannelButton';
 import { HomeTitle,ChannelWrapper} from './Home.styles';
-import { MainTopWrapper } from './../../commonPage.styles';
+
 
 const Home = () => {
   return (
     <>
       <TopBar NavType="main" />
-      <MainTopWrapper>
         <MainBanner />
         <HomeTitle>게임채널</HomeTitle>
         <ChannelWrapper>
@@ -19,7 +18,6 @@ const Home = () => {
           </Link>
           <ChannelButton title="랭킹 게임" />
         </ChannelWrapper>
-      </MainTopWrapper>
     </>
   );
 };

--- a/app/(nav)/placeRegister/page.tsx
+++ b/app/(nav)/placeRegister/page.tsx
@@ -3,15 +3,20 @@
 import TopBar from '@/components/Common/TopBar/TopBar';
 import PlaceRegister from '@/components/Layout/PlaceRegister/PlaceRegister';
 import { PlaceRegisterWrapper } from './PlaceRegister.styles';
+import { PageWrapper } from '@/app/commonPage.styles';
 
 const PlaceRegisterPage = () => {
   return (
-    <PlaceRegisterWrapper>
-      <TopBar NavType="default" label="장소 등록하기" />
-      <PlaceRegister title="장소1" currCount={0} totalCount={3} />
-      <PlaceRegister title="장소2" currCount={0} totalCount={3} />
-      <PlaceRegister title="장소3" currCount={0} totalCount={3} />
-    </PlaceRegisterWrapper>
+  <>
+    <TopBar NavType="default" label="장소 등록하기" />
+      <PageWrapper>
+        <PlaceRegisterWrapper>
+          <PlaceRegister title="장소1" currCount={0} totalCount={3} />
+          <PlaceRegister title="장소2" currCount={0} totalCount={3} />
+          <PlaceRegister title="장소3" currCount={0} totalCount={3} />
+        </PlaceRegisterWrapper>
+      </PageWrapper>
+    </>
   );
 };
 export default PlaceRegisterPage;

--- a/app/(nav)/rank/page.tsx
+++ b/app/(nav)/rank/page.tsx
@@ -1,10 +1,14 @@
+"use client";
 import TopBar from "@/components/Common/TopBar/TopBar";
+import { PageWrapper } from "@/app/commonPage.styles";
 
 const Rank = () => {
   return (
     <>
-      <TopBar NavType="other" label="랭킹"></TopBar>
-      <h1>Rank</h1>
+      <TopBar NavType="other" label="랭킹"/>
+      <PageWrapper>
+        
+      </PageWrapper>
     </>
   );
 };

--- a/app/commonPage.styles.ts
+++ b/app/commonPage.styles.ts
@@ -2,9 +2,6 @@ import styled from "styled-components";
 
 export const PageWrapper = styled.div`
   background-color: #FFFFFF;
-  padding-top: 40px
+  padding: 40px
 `;
 
-export const MainTopWrapper = styled.div`
-  padding-top:40px;
-`;

--- a/app/commonPage.styles.ts
+++ b/app/commonPage.styles.ts
@@ -2,5 +2,9 @@ import styled from "styled-components";
 
 export const PageWrapper = styled.div`
   background-color: #FFFFFF;
-  padding: 120px 8px 50px 8px;
+  padding-top: 40px
+`;
+
+export const MainTopWrapper = styled.div`
+  padding-top:40px;
 `;

--- a/app/commonPage.styles.ts
+++ b/app/commonPage.styles.ts
@@ -2,6 +2,6 @@ import styled from "styled-components";
 
 export const PageWrapper = styled.div`
   background-color: #FFFFFF;
-  padding: 40px
+  padding: 120px 8px 50px 8px;
 `;
 

--- a/app/makeRoom/page.tsx
+++ b/app/makeRoom/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 import TopBar from "@/components/Common/TopBar/TopBar";
-import { PageWrapper } from "../(nav)/commonPage.styles"
+import { PageWrapper } from "../commonPage.styles"
 
 const MakeRoomPage = () => {
   return (

--- a/components/Common/TopBar/TopBar.styles.ts
+++ b/components/Common/TopBar/TopBar.styles.ts
@@ -29,6 +29,7 @@ export const Nav = styled.nav<StyledTopBarProps>`
       : css`
           background-color: #F4EEFF;
           justify-content: flex-end;
+          padding-right: 16px;
         `}
 `;
 

--- a/components/Common/TopBar/TopBar.styles.ts
+++ b/components/Common/TopBar/TopBar.styles.ts
@@ -5,16 +5,17 @@ interface StyledTopBarProps {
 }
 
 export const Nav = styled.nav<StyledTopBarProps>`
-  position: absolute;
+  position: relative;
   left: 50%;
   transform: translateX(-50%);
-  width: 375px;
+  /* width: 375px; */
+  width: calc(100% + 46px);
   height: 40px;
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding-top:80px;
   z-index: 100;
+  top: 44px;
 
   ${({ $NavType }) =>
     $NavType === "default"
@@ -26,7 +27,7 @@ export const Nav = styled.nav<StyledTopBarProps>`
           background-color: white;
         `
       : css`
-          background-color: transparent;
+          background-color: #F4EEFF;
           justify-content: flex-end;
         `}
 `;
@@ -34,17 +35,15 @@ export const Nav = styled.nav<StyledTopBarProps>`
 export const BackIconWrapper = styled.div`
   display: flex;
   align-items: center;
-  margin-right: 10px;
-  cursor: pointer;
+  margin-left: 16px;
 `;
 
 export const RightIconsWrapper = styled.div`
   display: flex;
   align-items: center;
   gap: 10px;
-  cursor: pointer;
+  margin-right: 16px;
 `;
-
 
 export const Label = styled.div`
   flex: 1;

--- a/components/Common/TopBar/TopBar.styles.ts
+++ b/components/Common/TopBar/TopBar.styles.ts
@@ -5,45 +5,47 @@ interface StyledTopBarProps {
 }
 
 export const Nav = styled.nav<StyledTopBarProps>`
-  position: relative;
+  position: fixed; /* 화면 상단 고정 */
+  top: 44px;
   left: 50%;
   transform: translateX(-50%);
-  /* width: 375px; */
-  width: calc(100% + 46px);
+  right: 0;
+  width: 100%;
+  max-width: 375px; /* 최대 너비 설정 */
   height: 40px;
+  z-index: 100;
   display: flex;
   align-items: center;
   justify-content: space-between;
-  z-index: 100;
-  top: 44px;
 
   ${({ $NavType }) =>
     $NavType === "default"
       ? css`
           background-color: transparent;
+          box-shadow: 0px 2px 4px  rgba(0, 0, 0, 0.05);
         `
       : $NavType === "other"
       ? css`
           background-color: white;
+          box-shadow: 0px 2px 4px  rgba(0, 0, 0, 0.05);
         `
       : css`
-          background-color: #F4EEFF;
+          background-color: #f4eeff;
           justify-content: flex-end;
           padding-right: 16px;
         `}
 `;
 
+
 export const BackIconWrapper = styled.div`
   display: flex;
   align-items: center;
-  margin-left: 16px;
 `;
 
 export const RightIconsWrapper = styled.div`
   display: flex;
   align-items: center;
   gap: 10px;
-  margin-right: 16px;
 `;
 
 export const Label = styled.div`

--- a/components/Layout/Home/MainBanner/MainBanner.styles.ts
+++ b/components/Layout/Home/MainBanner/MainBanner.styles.ts
@@ -17,7 +17,7 @@ export const BannerWrapper = styled.div`
 export const ButtonWrapper = styled.div`
   position: absolute;
   bottom: 8px;
-  right: 16px;
+  right: 32px;
   display: flex;
   flex-direction: column;
   gap: 8px;

--- a/styles/Container.ts
+++ b/styles/Container.ts
@@ -3,7 +3,8 @@ import styled from 'styled-components';
 
 const Container = styled.div`
   width: 100%;
-  min-height: calc(var(--vh, 1vh) * 100);
+  height: 100%;
+  /* min-height: calc(var(--vh, 1vh) * 100); */
   min-width: 340px;
   max-width: 430px;
   background-color: #ffffff; /* 배경색 */
@@ -11,7 +12,8 @@ const Container = styled.div`
   display: flex;
   justify-content: center;
   margin: 0 auto; /* 화면 가운데 정렬 */
-  padding-bottom: 80px;
+  /* padding-bottom: 80px; */
+  overflow-x: hidden; 
 `;
 
 export default Container;


### PR DESCRIPTION
## #️⃣ 연관된 이슈

CSS 해결을 위한 PR 입니다.
(브랜치 삭제하지 말아주세요..!)

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
<img width="389" alt="스크린샷 2024-11-23 오후 6 09 37" src="https://github.com/user-attachments/assets/29ac2510-0a8c-4021-9ad0-3261a82fbc78">

<img width="389" alt="스크린샷 2024-11-23 오후 6 09 19" src="https://github.com/user-attachments/assets/efa9459e-a7a3-4fe3-9941-83f9c1b7066f">
<img width="389" alt="스크린샷 2024-11-23 오후 6 09 55" src="https://github.com/user-attachments/assets/eb75bf0c-09b3-4ddc-a7c3-d1cc5a85e366">
<img width="389" alt="스크린샷 2024-11-23 오후 6 10 19" src="https://github.com/user-attachments/assets/6fc23fa1-89cf-400c-ba9c-a6239183aa5a">
<img width="389" alt="스크린샷 2024-11-23 오후 6 10 45" src="https://github.com/user-attachments/assets/25499dd9-b200-4db7-8873-96cda72fbb21">

## 💬 리뷰 요구사항(선택)

### 추가 수정해야 할 부분
(일단 급한 부분은 수정해서 올려뒀고 추가로 수정해야하는 부분을 적어두겠습니다.)
- 상단 네비바 전체 shadow가 들어간 부분
- 로그인 기준으로 style을 만졌으나 회원가입에는 상단바가 들어가기에 (auth)부분 레이아웃을 공통으로 쓰지 않아야할 것 같습니다.
- 상단 네비바가 스크롤보다 위에 나타나는 부분

**혹시 상단 네비바가 스크롤했을때 사라지게 하는 방법을 아신다면 적용해주세요..🥹**
