### PR TITLE
Feat/#47: API 엔드 포인트 구현 및 서버 통신 구현

### DIFF
--- a/app/api/content/route.ts
+++ b/app/api/content/route.ts
@@ -1,0 +1,27 @@
+import axios from 'axios';
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function POST(request: NextRequest) {
+  const formData = await request.formData();
+  const params = request.nextUrl.searchParams;
+
+  try {
+    const res = await axios.post(
+      `${process.env.USER_CONTENT_API}/api/content-service/contents`,
+      formData,
+      {
+        headers: {
+          'Content-Type': 'multipart/form-data',
+        },
+        params: Object.fromEntries(params),
+      }
+    );
+    return NextResponse.json(res.data);
+  } catch (error) {
+    console.error(error);
+    return NextResponse.json(
+      { error: 'Failed to fetch data' },
+      { status: 500 }
+    );
+  }
+}

--- a/hooks/placeRegister/useUploadFiles.ts
+++ b/hooks/placeRegister/useUploadFiles.ts
@@ -21,17 +21,14 @@ const useUploadFiles = () => {
 
     // 서버에게 정보 전송
     axios
-      .post(
-        `${process.env.NEXT_PUBLIC_USER_CONTENT_API}/api/content-service/contents?${params.toString()}`,
-        formData,
-        {
-          headers: {
-            'Content-Type': 'multipart/form-data',
-          },
-        }
-      )
+      .post('/api/content', formData, {
+        headers: {
+          'Content-Type': 'multipart/form-data',
+        },
+        params: params,
+      })
       .then((res) => {
-        console.log(res);
+        console.log(res.status);
       })
       .catch((err) => {
         console.error(err);


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#47 

## 📝 작업 내용
- API 엔드 포인트를 구현했습니다.
- API 엔드 포인트를 통해 서버와 통신을 진행했습니다.
- [참고한 공식 주소](https://nextjs.org/docs/app/building-your-application/routing/route-handlers)

## 💬 리뷰 요구사항
- API 엔드 포인트 구현에 이상한 점이 있다면 알려주세요
  - 문제가 없다면, 앞으로 API 엔드 포인트를 사용하여 서버와의 통신을 진행해주세요-!