### PR TITLE
Feature/#63: 다중 장소 정보 업로드 및 API 로직 분리

### DIFF
--- a/app/(auth)/signup/page.tsx
+++ b/app/(auth)/signup/page.tsx
@@ -187,17 +187,16 @@ const Signup = () => {
           }
         />
         <SignupButton>
-        <Button
-          buttonType="gray"
-          buttonSize="large"
-          buttonHeight="default"
-          styleType="coloredBackground"
-          label="회원가입"
-          onClick={handleSignup}
-          disabled={isSubmitting}
-        />
+          <Button
+            buttonType="gray"
+            buttonSize="large"
+            buttonHeight="default"
+            styleType="coloredBackground"
+            label="회원가입"
+            onClick={handleSignup}
+            disabled={isSubmitting}
+          />
         </SignupButton>
-
       </SignupWrapper>
     </>
   );

--- a/app/(nav)/placeRegister/PlaceRegister.styles.ts
+++ b/app/(nav)/placeRegister/PlaceRegister.styles.ts
@@ -25,4 +25,5 @@ export const ButtonLayout = styled.div`
   background: ${colors.etc.white};
 
   box-sizing: border-box;
+  z-index: 10;
 `;

--- a/app/api/content/route.ts
+++ b/app/api/content/route.ts
@@ -1,4 +1,4 @@
-import axios from 'axios';
+import axiosInstance from '@/lib/axios';
 import { NextRequest, NextResponse } from 'next/server';
 
 export async function POST(request: NextRequest) {
@@ -6,8 +6,8 @@ export async function POST(request: NextRequest) {
   const params = request.nextUrl.searchParams;
 
   try {
-    const res = await axios.post(
-      `${process.env.USER_CONTENT_API}/api/content-service/contents/multiple`,
+    const res = await axiosInstance.post(
+      '/api/content-service/contents/multiple',
       formData,
       {
         headers: {

--- a/app/api/content/route.ts
+++ b/app/api/content/route.ts
@@ -1,8 +1,6 @@
+import { API_PORT_CONFIG, API_URL_CONFIG } from '@/config/apiEndPointConfig';
 import axiosInstance from '@/lib/axios';
 import { NextRequest, NextResponse } from 'next/server';
-
-const PORT = 8082;
-const CONTENT_POST_URL = '/api/content-service/contents/multiple';
 
 export async function POST(request: NextRequest) {
   const formData = await request.formData();
@@ -10,7 +8,7 @@ export async function POST(request: NextRequest) {
 
   try {
     const res = await axiosInstance.post(
-      `${axiosInstance.defaults.baseURL}:${PORT}${CONTENT_POST_URL}`,
+      `${axiosInstance.defaults.baseURL}:${API_PORT_CONFIG.CONTENT}${API_URL_CONFIG.CONTENT.POST_MULTIPLE}`,
       formData,
       {
         headers: {

--- a/app/api/content/route.ts
+++ b/app/api/content/route.ts
@@ -7,7 +7,7 @@ export async function POST(request: NextRequest) {
 
   try {
     const res = await axios.post(
-      `${process.env.USER_CONTENT_API}/api/content-service/contents`,
+      `${process.env.USER_CONTENT_API}/api/content-service/contents/multiple`,
       formData,
       {
         headers: {

--- a/app/api/signup/route.ts
+++ b/app/api/signup/route.ts
@@ -1,15 +1,13 @@
+import { API_PORT_CONFIG, API_URL_CONFIG } from '@/config/apiEndPointConfig';
 import axiosInstance from '@/lib/axios';
 import { NextRequest, NextResponse } from 'next/server';
-
-const PORT = 8081;
-const SIGNUP_POST_URL = '/api/user-service/users';
 
 export async function POST(request: NextRequest) {
   const data = await request.json();
 
   try {
     const res = await axiosInstance.post(
-      `${axiosInstance.defaults.baseURL}:${PORT}${SIGNUP_POST_URL}`,
+      `${axiosInstance.defaults.baseURL}:${API_PORT_CONFIG.AUTH}${API_URL_CONFIG.AUTH.SIGNUP}`,
       data,
       {
         headers: {

--- a/app/api/signup/route.ts
+++ b/app/api/signup/route.ts
@@ -1,25 +1,23 @@
 import axiosInstance from '@/lib/axios';
 import { NextRequest, NextResponse } from 'next/server';
 
-const PORT = 8082;
-const CONTENT_POST_URL = '/api/content-service/contents/multiple';
+const PORT = 8081;
+const SIGNUP_POST_URL = '/api/user-service/users';
 
 export async function POST(request: NextRequest) {
-  const formData = await request.formData();
-  const params = request.nextUrl.searchParams;
+  const data = await request.json();
 
   try {
     const res = await axiosInstance.post(
-      `${axiosInstance.defaults.baseURL}:${PORT}${CONTENT_POST_URL}`,
-      formData,
+      `${axiosInstance.defaults.baseURL}:${PORT}${SIGNUP_POST_URL}`,
+      data,
       {
         headers: {
-          'Content-Type': 'multipart/form-data',
+          'Content-Type': 'application/json',
         },
-        params: Object.fromEntries(params),
       }
     );
-    return NextResponse.json(res.data);
+    return NextResponse.json(res);
   } catch (error) {
     console.error(error);
     return NextResponse.json(

--- a/config/apiEndPointConfig.ts
+++ b/config/apiEndPointConfig.ts
@@ -1,0 +1,15 @@
+export const API_PORT_CONFIG = Object.freeze({
+  AUTH: 8081,
+  CONTENT: 8082,
+});
+
+export const API_URL_CONFIG = Object.freeze({
+  CONTENT: {
+    POST_MULTIPLE: '/api/content-service/contents/multiple',
+    POST_SINGLE: '/api/content-service/contents/',
+  },
+  AUTH: {
+    SIGNUP: '/api/auth/user-service/users',
+    LOGIN: '/api/auth/user-service/login',
+  },
+});

--- a/hooks/placeRegister/useUploadFiles.ts
+++ b/hooks/placeRegister/useUploadFiles.ts
@@ -8,7 +8,10 @@ const useUploadFiles = () => {
     const formData = new FormData();
 
     // 이미지 등록
-    formData.append('file', placeList[0].file[0]);
+    placeList[0].file.map((item) => {
+      console.log(item);
+      formData.append('files', item);
+    });
 
     // 장소명, 장소 위경도, 힌트 등록
     const params = new URLSearchParams();
@@ -19,20 +22,19 @@ const useUploadFiles = () => {
     params.append('longitude', '123.1');
 
     // 서버에게 정보 전송
-    console.log('placeRegister Result', placeList);
-    // axios
-    //   .post('/api/content', formData, {
-    //     headers: {
-    //       'Content-Type': 'multipart/form-data',
-    //     },
-    //     params: params,
-    //   })
-    //   .then((res) => {
-    //     console.log(res.status);
-    //   })
-    //   .catch((err) => {
-    //     console.error(err);
-    //   });
+    axios
+      .post('/api/content/', formData, {
+        headers: {
+          'Content-Type': 'multipart/form-data',
+        },
+        params: params,
+      })
+      .then((res) => {
+        console.log(res.status);
+      })
+      .catch((err) => {
+        console.error(err);
+      });
   };
 
   return {

--- a/hooks/placeRegister/useUploadFiles.ts
+++ b/hooks/placeRegister/useUploadFiles.ts
@@ -4,13 +4,13 @@ import usePlaceRegisterStore, { Place } from '@/stores/placeRegisterStore';
 const useUploadFiles = () => {
   const { placeList } = usePlaceRegisterStore();
 
-  const handleUploadFiles = () => {
-    placeList.map((place) => {
-      handleUploadPartFile(place);
-    });
+  const handleUploadFiles = async () => {
+    for (const place of placeList) {
+      await handleUploadPartFile(place);
+    }
   };
 
-  const handleUploadPartFile = (place: Place) => {
+  const handleUploadPartFile = async (place: Place) => {
     const formData = new FormData();
 
     // 이미지 등록
@@ -23,12 +23,12 @@ const useUploadFiles = () => {
     params.append('userId', '1');
     params.append('contentName', place.title);
     params.append('hint', place.hint);
+    params.append('address', '');
     params.append('latitude', '123.1');
     params.append('longitude', '123.1');
 
     // 서버에게 정보 전송
-    console.log(place);
-    axiosInstance
+    await axiosInstance
       .post('/api/content/', formData, {
         headers: {
           'Content-Type': 'multipart/form-data',

--- a/hooks/placeRegister/useUploadFiles.ts
+++ b/hooks/placeRegister/useUploadFiles.ts
@@ -1,27 +1,33 @@
-import usePlaceRegisterStore from '@/stores/placeRegisterStore';
+import usePlaceRegisterStore, { Place } from '@/stores/placeRegisterStore';
 import axios from 'axios';
 
 const useUploadFiles = () => {
   const { placeList } = usePlaceRegisterStore();
 
   const handleUploadFiles = () => {
+    placeList.map((place) => {
+      handleUploadPartFile(place);
+    });
+  };
+
+  const handleUploadPartFile = (place: Place) => {
     const formData = new FormData();
 
     // 이미지 등록
-    placeList[0].file.map((item) => {
-      console.log(item);
+    place.file.map((item) => {
       formData.append('files', item);
     });
 
     // 장소명, 장소 위경도, 힌트 등록
     const params = new URLSearchParams();
     params.append('userId', '1');
-    params.append('contentName', placeList[0].title);
-    params.append('hint', placeList[0].hint);
+    params.append('contentName', place.title);
+    params.append('hint', place.hint);
     params.append('latitude', '123.1');
     params.append('longitude', '123.1');
 
     // 서버에게 정보 전송
+    console.log(place);
     axios
       .post('/api/content/', formData, {
         headers: {

--- a/hooks/placeRegister/useUploadFiles.ts
+++ b/hooks/placeRegister/useUploadFiles.ts
@@ -1,5 +1,5 @@
+import axiosInstance from '@/lib/axios';
 import usePlaceRegisterStore, { Place } from '@/stores/placeRegisterStore';
-import axios from 'axios';
 
 const useUploadFiles = () => {
   const { placeList } = usePlaceRegisterStore();
@@ -28,7 +28,7 @@ const useUploadFiles = () => {
 
     // 서버에게 정보 전송
     console.log(place);
-    axios
+    axiosInstance
       .post('/api/content/', formData, {
         headers: {
           'Content-Type': 'multipart/form-data',

--- a/hooks/placeRegister/useUploadFiles.ts
+++ b/hooks/placeRegister/useUploadFiles.ts
@@ -30,9 +30,6 @@ const useUploadFiles = () => {
     // 서버에게 정보 전송
     await axiosInstance
       .post('/api/content/', formData, {
-        headers: {
-          'Content-Type': 'multipart/form-data',
-        },
         params: params,
       })
       .then((res) => {

--- a/lib/axios.ts
+++ b/lib/axios.ts
@@ -4,7 +4,7 @@ const axiosInstance = axios.create({
   baseURL: process.env.API_URL,
 });
 
-// // 요청/응답 인터셉터
+// 요청/응답 인터셉터
 // axiosInstance.interceptors.request.use(
 //   (config) => {
 //     // 요청 전 수행할 작업

--- a/lib/axios.ts
+++ b/lib/axios.ts
@@ -1,0 +1,18 @@
+import axios from 'axios';
+
+const axiosInstance = axios.create({
+  baseURL: process.env.API_URL,
+});
+
+// // 요청/응답 인터셉터
+// axiosInstance.interceptors.request.use(
+//   (config) => {
+//     // 요청 전 수행할 작업
+//     return config;
+//   },
+//   (error) => {
+//     return Promise.reject(error);
+//   }
+// );
+
+export default axiosInstance;

--- a/stores/placeRegisterStore.ts
+++ b/stores/placeRegisterStore.ts
@@ -1,6 +1,6 @@
 import { create } from 'zustand';
 
-interface Place {
+export interface Place {
   title: string;
   hint: string;
   file: File[];


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#63 

## 📝 작업 내용
### 개인 작업
- 하나의 장소에서 다중 파일 업로드 구현
- 다중 장소에서 다중 파일 업로드 구현
 
### API 로직 분리
#### 분리된 구조
  - API 클라이언트 설정 파일 분리 = `Backend 실제 URL` 정의 
  - API 엔드 포인트 정의 파일 분리 = 각각의 `서비스마다 사용하는 포트와 url` 한 곳에 모아 정의
  - API 사용 파일 분리 = 각각의 서비스마다 `실제 axios 호출하여 사용하는 로직` 정의
#### 분리된 파일 구조
```
app/
├── api/ // API 사용 파일 분리
│   ├── content/
│   │   └── route.ts
│   └── signup/
│       └── route.ts
config/
└── apiEndPointConfig.ts // API 엔드 포인트 정의 파일 분리
lib/
└── axios.ts // API 클라이언트 설정 파일 분리
```

## 💬 리뷰 요구사항
- 멘토링 때 논의했던 API 로직 분리를 진행했습니다!
- 🙋 더 분리해야 할 필요성이 있거나, 위치를 조정해야 할 필요성이 있는 부분 말씀해주세요!
