### PR TITLE
Feature/#72 로그인, 회원가입 고쳐야 할 것들 고쳤습니다.

### DIFF
--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -31,6 +31,7 @@ const Login = () => {
   const [password, setPassword] = useState('');
   const [errors, setErrors] = useState<LoginError>({ email: '', password: '' });
   const [isLoading, setIsLoading] = useState(false);
+  const [isFormValid, setIsFormValid] = useState(false);
 
   const handlePasswordVisibility = () => {
     setIsHiddenPassword((prev) => !prev);
@@ -59,6 +60,7 @@ const Login = () => {
     }
 
     setErrors(newErrors);
+    setIsFormValid(isValid);
     return isValid;
   };
 
@@ -96,6 +98,7 @@ const Login = () => {
         email: '',
         password: '이메일 또는 비밀번호가 올바르지 않습니다.',
       });
+      setIsFormValid(false);
     } finally {
       setIsLoading(false);
     }
@@ -112,7 +115,19 @@ const Login = () => {
         ...prev,
         email: '이메일 형식이 올바르지 않습니다 (예: xxx@xxx.com)',
       }));
+      setIsFormValid(false);
+    } else {
+      // 이메일이 유효하고 비밀번호가 있으면 폼 유효
+      setIsFormValid(!!value && !!password);
     }
+  };
+
+  const handlePasswordChange = (value: string) => {
+    setPassword(value);
+    setErrors({ ...errors, password: '' });
+
+    // 비밀번호가 있고 이메일이 유효하면 폼 유효
+    setIsFormValid(!!value && !!email && validateEmail(email));
   };
 
   return (
@@ -139,10 +154,7 @@ const Login = () => {
           isButton={true}
           isHiddenPassword={isHiddenPassword}
           handleClick={handlePasswordVisibility}
-          onChange={(value) => {
-            setPassword(value);
-            setErrors({ ...errors, password: '' });
-          }}
+          onChange={handlePasswordChange}
           type={isHiddenPassword ? 'password' : 'text'}
           autoComplete="new-password"
           validation={
@@ -154,7 +166,7 @@ const Login = () => {
         <AutoLoginCheckbox />
         <ButtonSignupWrapper>
           <Button
-            buttonType="gray"
+            buttonType={isFormValid ? 'purple' : 'gray'}
             buttonSize="large"
             buttonHeight="default"
             styleType="coloredBackground"

--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
+import toast from 'react-hot-toast';
 import {
   LoginWrapper,
   LoginTitle,
@@ -31,16 +32,34 @@ const Login = () => {
   const [errors, setErrors] = useState<LoginError>({ email: '', password: '' });
   const [isLoading, setIsLoading] = useState(false);
 
-  const handlePasswordVisibility = (e: React.MouseEvent) => {
-    e.preventDefault();
+  const handlePasswordVisibility = () => {
     setIsHiddenPassword((prev) => !prev);
   };
 
+  const validateEmail = (email: string): boolean => {
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    return emailRegex.test(email);
+  };
+
   const validateForm = (): boolean => {
-    if (email && password) {
-      return true;
+    let isValid = true;
+    const newErrors = { email: '', password: '' };
+
+    // 이메일 검증
+    if (email) {
+      if (!validateEmail(email)) {
+        newErrors.email = '이메일 형식이 올바르지 않습니다 (예: xxx@xxx.com)';
+        isValid = false;
+      }
     }
-    return false;
+
+    // 기존 빈 값 검증
+    if (!email || !password) {
+      isValid = false;
+    }
+
+    setErrors(newErrors);
+    return isValid;
   };
 
   const handleLogin = async (e: React.FormEvent) => {
@@ -69,6 +88,7 @@ const Login = () => {
 
       const nickname = await response.text();
       setNickname(nickname);
+      toast(`안녕하세요 ${nickname}님 환영합니다!`);
       router.push('/home');
     } catch (error) {
       console.error('Login error:', error);
@@ -78,6 +98,20 @@ const Login = () => {
       });
     } finally {
       setIsLoading(false);
+    }
+  };
+
+  const handleEmailChange = (value: string) => {
+    setEmail(value);
+    if (errors.email) {
+      setErrors({ ...errors, email: '' });
+    }
+
+    if (value && !validateEmail(value)) {
+      setErrors((prev) => ({
+        ...prev,
+        email: '이메일 형식이 올바르지 않습니다 (예: xxx@xxx.com)',
+      }));
     }
   };
 
@@ -91,10 +125,7 @@ const Login = () => {
         <Input
           title="이메일"
           placeholder="이메일을 입력해주세요"
-          onChange={(value) => {
-            setEmail(value);
-            setErrors({ ...errors, email: '' });
-          }}
+          onChange={handleEmailChange}
           autoComplete="new-email"
           validation={
             errors.email ? (

--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -31,34 +31,24 @@ const Login = () => {
   const [errors, setErrors] = useState<LoginError>({ email: '', password: '' });
   const [isLoading, setIsLoading] = useState(false);
 
-  const handlePasswordVisibility = () => {
+  const handlePasswordVisibility = (e: React.MouseEvent) => {
+    e.preventDefault();
     setIsHiddenPassword((prev) => !prev);
   };
 
   const validateForm = (): boolean => {
-    const newErrors = { email: '', password: '' };
-    let isValid = true;
-
-    if (!email) {
-      newErrors.email = '이메일을 입력해주세요.';
-      isValid = false;
+    if (email && password) {
+      return true;
     }
-
-    if (!password) {
-      newErrors.password = '비밀번호를 입력해주세요.';
-      isValid = false;
-    }
-
-    setErrors(newErrors);
-    return isValid;
+    return false;
   };
 
-  const handleLogin = async (e?: React.FormEvent) => {
-    if (e) {
-      e.preventDefault();
-    }
+  const handleLogin = async (e: React.FormEvent) => {
+    e.preventDefault();
 
-    if (!validateForm()) return;
+    if (!validateForm()) {
+      return;
+    }
 
     setIsLoading(true);
     try {
@@ -101,12 +91,15 @@ const Login = () => {
         <Input
           title="이메일"
           placeholder="이메일을 입력해주세요"
-          onChange={(value) => setEmail(value)}
+          onChange={(value) => {
+            setEmail(value);
+            setErrors({ ...errors, email: '' });
+          }}
           autoComplete="new-email"
           validation={
-            errors.email && (
+            errors.email ? (
               <ValidationMessage message={errors.email} type="error" />
-            )
+            ) : null
           }
         />
         <Input
@@ -115,13 +108,16 @@ const Login = () => {
           isButton={true}
           isHiddenPassword={isHiddenPassword}
           handleClick={handlePasswordVisibility}
-          onChange={(value) => setPassword(value)}
+          onChange={(value) => {
+            setPassword(value);
+            setErrors({ ...errors, password: '' });
+          }}
           type={isHiddenPassword ? 'password' : 'text'}
           autoComplete="new-password"
           validation={
-            errors.password && (
+            errors.password ? (
               <ValidationMessage message={errors.password} type="error" />
-            )
+            ) : null
           }
         />
         <AutoLoginCheckbox />

--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -13,7 +13,6 @@ import Input from '@common/Input/Input';
 import AutoLoginCheckbox from '@layout/Login/AutoLogin';
 import Button from '@common/Button/Button';
 import SignupTabs from '@layout/Login/SignUpTabs';
-import SocialLogin from '@/components/Layout/Login/SNSLogos';
 import useUserStore from '@/stores/useUserStore';
 import ValidationMessage from '@/components/Common/ValidationMessage/ValidationMessage';
 
@@ -105,7 +104,9 @@ const Login = () => {
           onChange={(value) => setEmail(value)}
           autoComplete="new-email"
           validation={
-            errors.email && <ValidationMessage message={errors.email} />
+            errors.email && (
+              <ValidationMessage message={errors.email} type="error" />
+            )
           }
         />
         <Input
@@ -118,7 +119,9 @@ const Login = () => {
           type={isHiddenPassword ? 'password' : 'text'}
           autoComplete="new-password"
           validation={
-            errors.password && <ValidationMessage message={errors.password} />
+            errors.password && (
+              <ValidationMessage message={errors.password} type="error" />
+            )
           }
         />
         <AutoLoginCheckbox />
@@ -134,7 +137,6 @@ const Login = () => {
           <SignupTabs />
         </ButtonSignupWrapper>
       </form>
-      {/* <SocialLogin /> */}
     </LoginWrapper>
   );
 };

--- a/app/(auth)/signup/page.tsx
+++ b/app/(auth)/signup/page.tsx
@@ -1,4 +1,5 @@
 'use client';
+
 import { useState, useCallback } from 'react';
 import { useRouter } from 'next/navigation';
 import NickNameInput from '@/components/Layout/Signup/NickNameInput';
@@ -139,7 +140,7 @@ const Signup = () => {
           onChange={(value) =>
             setFormData((prev) => ({ ...prev, email: value }))
           }
-          autoComplete="off" // 자동완성 방지
+          autoComplete="off"
         />
         <Input
           title="비밀번호"
@@ -156,14 +157,20 @@ const Signup = () => {
             }
           }}
           type={isHiddenPassword.origin ? 'password' : 'text'}
-          autoComplete="new-password" // 자동완성 방지
+          autoComplete="new-password"
           validation={
             <>
               {errors.length && (
-                <ValidationMessage message="비밀번호는 8자리 이상이어야 합니다." />
+                <ValidationMessage
+                  message="비밀번호는 8자리 이상이어야 합니다."
+                  type="error"
+                />
               )}
               {errors.pattern && (
-                <ValidationMessage message="비밀번호는 숫자, 영문, 특수문자를 포함해야 합니다." />
+                <ValidationMessage
+                  message="비밀번호는 숫자, 영문, 특수문자를 포함해야 합니다."
+                  type="error"
+                />
               )}
             </>
           }
@@ -179,10 +186,13 @@ const Signup = () => {
             validatePasswordMatch(value);
           }}
           type={isHiddenPassword.copy ? 'password' : 'text'}
-          autoComplete="new-password" // 자동완성 방지
+          autoComplete="new-password"
           validation={
             errors.mismatch && (
-              <ValidationMessage message="비밀번호가 일치하지 않습니다." />
+              <ValidationMessage
+                message="비밀번호가 일치하지 않습니다."
+                type="error"
+              />
             )
           }
         />

--- a/app/(auth)/signup/page.tsx
+++ b/app/(auth)/signup/page.tsx
@@ -2,12 +2,14 @@
 
 import { useState, useCallback } from 'react';
 import { useRouter } from 'next/navigation';
+import toast from 'react-hot-toast';
 import NickNameInput from '@/components/Layout/Signup/NickNameInput';
 import Input from '@/components/Common/Input/Input';
 import { SignupButton, SignupWrapper, Title } from './Signup.styles';
 import TopBar from '@/components/Common/TopBar/TopBar';
 import ValidationMessage from '@/components/Common/ValidationMessage/ValidationMessage';
 import Button from '@/components/Common/Button/Button';
+import useUserStore from '@/stores/useUserStore';
 
 interface SignUpFormData {
   email: string;
@@ -17,6 +19,8 @@ interface SignUpFormData {
 
 const Signup = () => {
   const router = useRouter();
+  const setNickname = useUserStore((state) => state.setNickname);
+
   const [formData, setFormData] = useState<SignUpFormData>({
     email: '',
     password: '',
@@ -107,7 +111,8 @@ const Signup = () => {
       );
 
       if (response.ok) {
-        alert('회원가입이 완료되었습니다.');
+        setNickname(formData.nickname);
+        toast(`안녕하세요 ${formData.nickname}님`);
         router.push('/login');
       } else {
         const errorData = await response.text();

--- a/app/(auth)/signup/page.tsx
+++ b/app/(auth)/signup/page.tsx
@@ -143,7 +143,7 @@ const Signup = () => {
 
       if (response.ok) {
         setNickname(formData.nickname);
-        toast(`안녕하세요 ${formData.nickname}님`);
+        toast('회원가입에 성공하셨습니다!');
         router.push('/login');
       } else {
         const errorData = await response.text();

--- a/components/Common/ValidationMessage/ValidationMessage.styles.ts
+++ b/components/Common/ValidationMessage/ValidationMessage.styles.ts
@@ -1,9 +1,10 @@
 import styled from 'styled-components';
 import colors from '@styles/color/palette';
 
-export const StyledMessage = styled.div`
+export const StyledMessage = styled.div<{ type: 'success' | 'error' }>`
   padding-top: 4px;
-  color: ${colors.alert[50]};
+  color: ${({ type }) =>
+    type === 'success' ? colors.etc.green : colors.alert[50]};
   font-size: 12px;
   margin: 0;
 `;

--- a/components/Common/ValidationMessage/ValidationMessage.tsx
+++ b/components/Common/ValidationMessage/ValidationMessage.tsx
@@ -2,10 +2,11 @@ import { StyledMessage } from '@/components/Common/ValidationMessage/ValidationM
 
 interface ValidationMessageProps {
   message: string;
+  type: 'success' | 'error'; // 'success'는 green, 'error'는 alert 색상
 }
 
-const ValidationMessage = ({ message }: ValidationMessageProps) => {
-  return <StyledMessage>{message}</StyledMessage>;
+const ValidationMessage = ({ message, type }: ValidationMessageProps) => {
+  return <StyledMessage type={type}>{message}</StyledMessage>;
 };
 
 export default ValidationMessage;

--- a/components/Layout/MakeRoom/FriendsInviteForm.styles.ts
+++ b/components/Layout/MakeRoom/FriendsInviteForm.styles.ts
@@ -15,6 +15,7 @@ export const Title = styled.h2`
   display: flex;
   align-items: center;
   font-size: 16px;
+  font-weight: 600;
   margin: 0;
 `;
 
@@ -102,6 +103,7 @@ export const InvitedFriendsTitle = styled.h3`
   display: flex;
   align-items: center;
   font-size: 16px;
+  font-weight: 600;
   margin: 0;
 `;
 

--- a/components/Layout/Signup/NickNameInput.tsx
+++ b/components/Layout/Signup/NickNameInput.tsx
@@ -10,17 +10,21 @@ interface NickNameInputProps {
 
 const NickNameInput = ({ onNicknameValidated }: NickNameInputProps) => {
   const [nickname, setNickname] = useState('');
-  const [validationMessage, setValidationMessage] = useState<string>('');
-  const [isChecking, setIsChecking] = useState(false);
+  const [validationMessage, setValidationMessage] = useState<{
+    message: string;
+    type: 'success' | 'error';
+  } | null>(null);
 
   const checkNicknameDuplicate = async () => {
     if (!nickname) {
-      setValidationMessage('닉네임을 입력해주세요.');
+      setValidationMessage({
+        message: '닉네임을 입력해주세요.',
+        type: 'error',
+      });
       onNicknameValidated('', false);
       return;
     }
 
-    setIsChecking(true);
     try {
       const response = await fetch(
         `${process.env.NEXT_PUBLIC_API_URL}/api/user-service/nickname`,
@@ -37,28 +41,38 @@ const NickNameInput = ({ onNicknameValidated }: NickNameInputProps) => {
 
       if (response.ok) {
         if (result === 'PERMIT') {
-          setValidationMessage('사용 가능한 닉네임입니다.');
+          setValidationMessage({
+            message: '사용 가능한 닉네임입니다.',
+            type: 'success',
+          });
           onNicknameValidated(nickname, true);
         } else if (result === 'DUPLICATED') {
-          setValidationMessage('이미 사용 중인 닉네임입니다.');
+          setValidationMessage({
+            message: '이미 사용 중인 닉네임입니다.',
+            type: 'error',
+          });
           onNicknameValidated(nickname, false);
         }
       } else {
-        setValidationMessage('중복 확인 중 오류가 발생했습니다.');
+        setValidationMessage({
+          message: '중복 확인 중 오류가 발생했습니다.',
+          type: 'error',
+        });
         onNicknameValidated(nickname, false);
       }
     } catch (error) {
       console.error('Nickname check error:', error);
-      setValidationMessage('중복 확인 중 오류가 발생했습니다.');
+      setValidationMessage({
+        message: '중복 확인 중 오류가 발생했습니다.',
+        type: 'error',
+      });
       onNicknameValidated(nickname, false);
-    } finally {
-      setIsChecking(false);
     }
   };
 
   const handleInputChange = (value: string) => {
     setNickname(value);
-    setValidationMessage('');
+    setValidationMessage(null);
     onNicknameValidated(value, false); // 입력값이 변경되면 유효성 초기화
   };
 
@@ -71,7 +85,10 @@ const NickNameInput = ({ onNicknameValidated }: NickNameInputProps) => {
           onChange={handleInputChange}
           validation={
             validationMessage && (
-              <ValidationMessage message={validationMessage} />
+              <ValidationMessage
+                message={validationMessage.message}
+                type={validationMessage.type}
+              />
             )
           }
         />

--- a/styles/color/palette.ts
+++ b/styles/color/palette.ts
@@ -19,6 +19,7 @@ const colors = {
   etc: {
     black: 'rgba(26, 28, 28, 1)',
     white: 'rgba(255, 255, 255, 1)',
+    green: 'rgba(67, 195, 59, 1)',
   },
   alert: {
     50: 'rgba(222, 55, 48, 1)',


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#72 

## 📝 작업 내용
- [x]  로그인 & 회원가입 [[react toast](https://www.npmjs.com/package/react-toastify)](https://www.npmjs.com/package/react-toastify)
- [x]  회원가입 닉네임 중복확인 “가능한 닉네임 입니다” 초록색으로 변경
- [x]  로그인에서 다음 페이지로 넘어갈 때 validation과 가려졌던 비밀번호가 보임
- [x]  폼 다 작성 하면 버튼 보라색으로 활성화 되어야 함

## 💬 리뷰 요구사항(선택)
더 고쳐야 할 것들이 있다면 말씀해주세요!
