### PR TITLE
Fix: PlaceRegister Page useSearchParams() 문제 해결 위해 layout에 Suspense 추가

### DIFF
--- a/app/(nav)/placeRegister/layout.tsx
+++ b/app/(nav)/placeRegister/layout.tsx
@@ -1,5 +1,5 @@
 import Script from 'next/script';
-import React from 'react';
+import React, { Suspense } from 'react';
 
 export default function PlaceRegisterLayout({
   children,
@@ -7,12 +7,12 @@ export default function PlaceRegisterLayout({
   children: React.ReactNode;
 }) {
   return (
-    <>
+    <Suspense>
       <Script
         id="google-maps-script"
         src={`https://maps.googleapis.com/maps/api/js?key=${process.env.NEXT_PUBLIC_LOCATION_REGISTER_GOOGLE_MAPS_API_KEY}&libraries=places&loading=async`}
       />
       <>{children}</>
-    </>
+    </Suspense>
   );
 }


### PR DESCRIPTION
## 😱 에러 메시지
```
useSearchParams() should be wrapped in a suspense boundary at page "/placeRegister". Read more: https://nextjs.org/docs/messages/missing-suspense-with-csr-bailout
```

## 📝 작업 내용
- vercel 배포 시에 발생하는 문제를 해결했습니다.
- placeRegister 페이지에서 useSearchParams()를 사용하는 문제를 해결하기 위해 Suspense를 layout에 부여했습니다.
